### PR TITLE
feat: Service に incr を追加

### DIFF
--- a/config/lib.yaml
+++ b/config/lib.yaml
@@ -6,7 +6,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/ginseng-redis
-  version: 2.0.3
+  version: 2.0.4
 redis:
   dsn: null
   retry:

--- a/lib/ginseng/redis/service.rb
+++ b/lib/ginseng/redis/service.rb
@@ -62,6 +62,17 @@ module Ginseng
         retry
       end
 
+      def incr(key)
+        cnt ||= 0
+        return redis.call('INCR', create_key(key))
+      rescue => e
+        cnt += 1
+        @logger.error(error: e, count: cnt)
+        raise Error, e.message, e.backtrace unless cnt < retry_limit
+        sleep(retry_seconds)
+        retry
+      end
+
       def key?(key)
         return keys(create_key(key)).present?
       end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -26,6 +26,16 @@ module Ginseng
         assert_equal(1, @service.del(__dir__))
       end
 
+      def test_incr
+        key = SecureRandom.hex
+        @service.del(key)
+
+        assert_equal(1, @service.incr(key))
+        assert_equal(2, @service.incr(key))
+        assert_equal('2', @service.get(key))
+        @service.del(key)
+      end
+
       def test_save
         assert(@service.save)
       end


### PR DESCRIPTION
## 背景

`Ginseng::Redis::Service` は `get/set/setex/key?/unlink(=del)/save/keys` を公開するが **`incr` が未実装**。利用側の mulukhiya-toot-proxy `StartupNotificationWorker#bump_ng_count` が `redis.incr` を呼んでおり、環境に依らず `NoMethodError: undefined method 'incr'` になっていた（ヘルス NG 時のヒステリシス通知が本番で沈黙）。

参照: pooza/mulukhiya-toot-proxy#4448

## 変更

- `Service#incr(key)` を追加（`redis.call('INCR', create_key(key))`、`setex`/`unlink` と同じ retry ラッパー）。
- `test/service_test.rb#test_incr` 追加。
- version 2.0.3 → 2.0.4。

## 確認

- `rake test`: 11 tests / 0 failures / 0 errors（`test_incr` 含む・要 localhost redis）。
- 既存 offense `Layout/EmptyLinesAfterModuleInclusion`（service.rb:6）は本 PR 対象外の既存指摘（rubocop cop 追加由来）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)