### PR TITLE
CI でテストを実行し、週次でも走らせる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 on:
-  - push
+  push:
+  # ⚠ push 契機だけだと、更新が止まったときに赤へ気づけない。
+  schedule:
+    - cron: '25 0 * * 1'
 env:
   CI: 'true'
 jobs:
@@ -13,19 +16,20 @@ jobs:
           - ruby:3.3
           - ruby:3.4
           - ruby:4.0
+    # ⚠ services は gem ごとに違うので呼び出し側に残す。
     services:
       redis:
         image: redis:7
-        ports:
-          - 6379:6379
     steps:
-      - uses: actions/checkout@v3
-      - name: bundle install
+      - uses: actions/checkout@v5
+      # ⚠ config/local.yaml は gitignore されているので CI には無い。DSN が無いと
+      # Service が繋げずテストが落ちる。⚠⚠ container ジョブでは service の
+      # ホスト名は localhost ではなくサービス名（redis）になる。
+      - name: config
         run: |
-          gem install bundler -v '~>2.0'
-          bundle install --jobs 4 --retry 3
-          bundle exec rake bundle:update
-          bundle exec rake bundle:check
-      - name: Run lint
-        run: |
-          bundle exec rubocop
+          cat > config/local.yaml <<'YAML'
+          redis:
+            dsn: redis://redis:6379/1
+          YAML
+      # ⚠ 手順の正本は pooza/ginseng-style。ここには matrix と services と schedule だけ置く。
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@main


### PR DESCRIPTION
## なぜ

⚠ **この CI は `rake test` を呼んでいなかった。** 14 件のテストが一度も走っていない。`ginseng-*` 全 7 gem に共通する問題で、横断の経緯は pooza/ginseng-style#2 にある。

## 何をしたか

手順の正本を `pooza/ginseng-style` の composite action に寄せ、このリポジトリには `matrix` と `services` と `schedule` だけ残した。

| 手順 | 従来 | この PR |
| --- | --- | --- |
| `bundle install` | ✅ | ✅ |
| `rake bundle:update` | ✅ | ✅ |
| `rake bundle:check` | ✅ | ✅ |
| `rubocop` | ✅ | ✅ |
| **`rake test`** | 🔴 なし | ✅ |

## ⚠⚠ このリポジトリ固有の対応

テストを実際に走らせると、これまで露見しなかった問題が 2 つ出る。

1. **`config/local.yaml` は gitignore されている**（`config/.gitignore` の `local.*`）ので CI に存在しない。`config/lib.yaml` の `/redis/dsn` は `null` なので、`Service` が接続先を得られない
2. **container ジョブでは service のホスト名が `localhost` ではなくサービス名になる。** `ports:` のマッピングはランナー実行のときの仕組みで、container ジョブでは効かない

そのため、composite action を呼ぶ前に `config/local.yaml` を書き出すステップを置いた。

```yaml
      - name: config
        run: |
          cat > config/local.yaml <<'YAML'
          redis:
            dsn: redis://redis:6379/1
          YAML
```

⚠ 従来の `ports: - 6379:6379` は container ジョブでは意味を持たないので外した。

## 確認

- ✅ ローカルで `bundle exec rake test` — 14 tests, 23 assertions, 0 failures, 0 errors
- ✅ ローカルで `bundle exec rubocop` — 13 files inspected, no offenses detected
- ✅ 同じ変更を pooza/ginseng-web#117 で先に通し、CI でテストが実行されて緑になることを確認済み

⚠ **この PR は上の 2 点があるため、CI が実際に緑になるかを見てから判断する。**