### PR TITLE
feat: CI の権限を絞り、workflow_dispatch を足す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,13 @@ on:
   # ⚠ push 契機だけだと、更新が止まったときに赤へ気づけない。
   schedule:
     - cron: '25 0 * * 1'
+  # ⚠ schedule: は 60 日の無活動で GitHub に無効化される。ginseng-style の
+  # gem-watch から起こせるようにしておく。
+  workflow_dispatch:
+# ⚠⚠ 手順本体は pooza/ginseng-style の composite action を @main で参照している。
+# そこに入った変更が、このリポジトリの GITHUB_TOKEN を持って動く。既定に頼らず絞る。
+permissions:
+  contents: read
 env:
   CI: 'true'
 jobs:
@@ -22,6 +29,10 @@ jobs:
         image: redis:7
     steps:
       - uses: actions/checkout@v5
+        with:
+          # ⚠ 既定では認証情報がワークツリーの git config に残る。依存 gem は
+          # public な github: 参照なので、消しても bundle install に影響しない。
+          persist-credentials: false
       # ⚠ config/local.yaml は gitignore されているので CI には無い。DSN が無いと
       # Service が繋げずテストが落ちる。⚠⚠ container ジョブでは service の
       # ホスト名は localhost ではなくサービス名（redis）になる。


### PR DESCRIPTION
[pooza/ginseng-style#50](https://github.com/pooza/ginseng-style/pull/50) と [#51](https://github.com/pooza/ginseng-style/pull/51) の配布。

⚠ **先行して [pooza/ginseng-fediverse#252](https://github.com/pooza/ginseng-fediverse/pull/252) で試し、CI 緑を確認済み**（`ruby:3.4` / `ruby:4.0` とも success）。[変更手順](https://github.com/pooza/ginseng-style/blob/main/docs/CLAUDE.md) の 2. → 3.。

## 変更

| 追加 | 理由 |
| --- | --- |
| `permissions: contents: read` | 手順本体は `@main` 参照なので、**`ginseng-style` の main に入った変更がこのリポジトリの `GITHUB_TOKEN` を持って動く**。既定に頼らず絞る |
| `persist-credentials: false` | ⚠ 既定では認証情報がワークツリーの `git config` に残り、後続ステップから使える |
| `workflow_dispatch:` | ⚠⚠ public リポジトリの `schedule:` は **60 日の無活動で GitHub が自動的に無効化する**（[GitHub Docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)）。`ginseng-style` の `gem-watch` から起こせるようにする |

## ⚠ `persist-credentials: false` の影響

依存は **public な `github:` 参照**。`actions/checkout` が置く `http.https://github.com/.extraheader` は**チェックアウトしたリポジトリのローカル設定**なので、bundler の別クローンには効かない。消しても `bundle install` に影響しない。fediverse で実証済み。

## ⚠ このリポジトリ側で別途必要な設定

**Settings → Actions → General → Workflow permissions を read に落とす。** ファイルの `permissions:` は**この workflow にしか効かない**ので、両方要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
