### PR TITLE
chore: ginseng-style の参照を v1.1.0 に固定する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   # ⚠ schedule: は 60 日の無活動で GitHub に無効化される。ginseng-style の
   # gem-watch から起こせるようにしておく。
   workflow_dispatch:
-# ⚠⚠ 手順本体は pooza/ginseng-style の composite action を @main で参照している。
+# ⚠⚠ 手順本体は pooza/ginseng-style の composite action。版で固定しているが、
 # そこに入った変更が、このリポジトリの GITHUB_TOKEN を持って動く。既定に頼らず絞る。
 permissions:
   contents: read
@@ -43,4 +43,4 @@ jobs:
             dsn: redis://redis:6379/1
           YAML
       # ⚠ 手順の正本は pooza/ginseng-style。ここには matrix と services と schedule だけ置く。
-      - uses: pooza/ginseng-style/.github/actions/ruby-check@main
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'ginseng-core', github: 'pooza/ginseng-core', require: 'ginseng'
 
 group :development, :test do
   # ⚠ rubocop 本体とプラグインはこの gem が依存として持つ。設定の正本も同じ場所。
-  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
 end


### PR DESCRIPTION
`ginseng-style` の参照を **版（タグ `v1.1.0`）で固定**する。⚠ **横断の方針決定は [pooza/ginseng-style#53](https://github.com/pooza/ginseng-style/issues/53) / [#32](https://github.com/pooza/ginseng-style/issues/32)、実装は [pooza/ginseng-style#54](https://github.com/pooza/ginseng-style/pull/54)。**

## 経緯

`ginseng-style` は RuboCop 設定と CI 手順の正本で、ここからは 2 経路で参照している。**どちらも `main` を追う形だった。**

| 経路 | 何が入ってくるか |
| --- | --- |
| `Gemfile` の `branch: 'main'` | RuboCop の設定と rubocop 本体・プラグイン |
| `test.yml` の `ruby-check@main` | CI の手順本体（composite action）。⚠ このリポジトリの `GITHUB_TOKEN` を持って動く |

### 🔴 実測 — 手元と CI が 48 コミット違う設定を見ていた

`ginseng-core` で踏んだ。**同じコミットで手元は赤・CI は緑**だった（手元だけ `Minitest/AssertPathExists` が出る）。

⚠⚠ **原因は `bundle update` ではない。** gem 側は `Gemfile.lock` を `.gitignore` しているので、**CI のチェックアウトには lock がそもそも存在しない**。`bundle install` の時点で `branch: 'main'` の HEAD が解決される。2026-08-23 時点で gem 側 7 本すべて、手元は 2026-08-19 の版・CI は `main` を見ていた。

### ⚠⚠ 危ないのは逆向き

いまの形では、**`ginseng-style` に cop が足された瞬間、こちらが 1 行もコミットしていないのに次の push で CI が赤くなる。** `NewCops: enable` があるので rubocop 本体の更新でも同じ。正本側の「1 リポジトリで試してから配る」という手順が、配る前に届いてしまうので前提から崩れていた。

## 変更

```diff
-  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
```

```diff
-      - uses: pooza/ginseng-style/.github/actions/ruby-check@main
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.0
```

⚠ **版で固定しても、composite action がこのリポジトリの `GITHUB_TOKEN` で動く性質は消えない。** `permissions: contents: read` と `persist-credentials: false` は固定とは別に要る（既に入っている）。コメントの文言だけ実態に合わせた。

## 実測（この変更の前後）

`v1.1.0` は `ginseng-style` の現在の `main`（`fd65197`）と同じコミットなので、**CI から見れば no-op**。

- `Gemfile.lock` が解決した revision: `fd65197dbb`（固定前と同じ）
- `bundle exec rubocop`: **no offenses**
- ⚠ 1 本目の `ginseng-core`（[#567](https://github.com/pooza/ginseng-core/pull/567)）では `--show-cops` と `--list-target-files` の差分がどちらも**ゼロ**、CI も 3/3 緑であることを確認済み

## これから

- ⚠ **版を上げるのは `Gemfile` と `test.yml` の 2 行を書き換える明示的な操作になる。** `ginseng-style` 側で設定を変えたら、向こうから PR が来る
- ⚠ 古い版で止まったままにならないよう、`ginseng-style` の `gem-watch` が週次で見る（**未固定は落とす／古いだけなら落とさない**）
