### PR TITLE
chore: テスト対象を 3.4 / 4.0 に揃える (pooza/ginseng-style#61)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - ruby:3.3
           - ruby:3.4
           - ruby:4.0
     # ⚠ services は gem ごとに違うので呼び出し側に残す。

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,4 +5,4 @@ inherit_gem:
   ginseng-style: config/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4

--- a/ginseng-redis.gemspec
+++ b/ginseng-redis.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = package['url']
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>=3.3'
+  spec.required_ruby_version = '>=3.4'
 
   spec.add_dependency 'redis-client'
   spec.add_development_dependency 'ricecream'


### PR DESCRIPTION
pooza/ginseng-style#61 の一環。

## 何を変えたか

CI の matrix が gem ごとに違っていた（3.3 込みが 5 本、3.4 からが 3 本）。**3.4 / 4.0 に寄せる。**

⚠ **Ruby の版は 1 リポジトリに 3 箇所ある。** matrix だけ落とすと「サポートすると宣言しているのにテストしていない」になるので 3 つとも上げた。

| 箇所 | 前 | 後 |
| --- | --- | --- |
| `.github/workflows/test.yml` の matrix | 3.3 / 3.4 / 4.0 | **3.4 / 4.0** |
| gemspec の `required_ruby_version` | `>=3.3` | **`>=3.4`** |
| `.rubocop.yml` の `TargetRubyVersion` | 3.3 | **3.4** |

## ✅ 落として困る利用側は無い（実測）

`mulukhiya-toot-proxy` / `makoto2` / `tomato-shrieker` / `cure-api` / `loquat` は**全て `.ruby-version` が 4.0.6**、かつ**全て `TargetRubyVersion` を自分で上書き**している。

⚠ **`ginseng-core` だけは 3.3 を残す**（ユーザー判断）。あちらは `.rubocop.yml` で明示しているので、配る既定が 3.4 になっても影響しない。
