### PR TITLE
chore: ginseng-style を v1.1.4 に上げる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
             dsn: redis://redis:6379/1
           YAML
       # ⚠ 手順の正本は pooza/ginseng-style。ここには matrix と services と schedule だけ置く。
-      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.3
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
             dsn: redis://redis:6379/1
           YAML
       # ⚠ 手順の正本は pooza/ginseng-style。ここには matrix と services と schedule だけ置く。
-      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.0
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'ginseng-core', github: 'pooza/ginseng-core', require: 'ginseng'
 
 group :development, :test do
   # ⚠ rubocop 本体とプラグインはこの gem が依存として持つ。設定の正本も同じ場所。
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.3', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'ginseng-core', github: 'pooza/ginseng-core', require: 'ginseng'
 
 group :development, :test do
   # ⚠ rubocop 本体とプラグインはこの gem が依存として持つ。設定の正本も同じ場所。
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.3', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.4', require: false
 end


### PR DESCRIPTION
`v1.1.0` → `v1.1.3`。⚠ **`Gemfile` の `tag:` と `test.yml` の `ruby-check@` を同じ版に揃えた。**

## v1.1.1 → v1.1.3 で変わったもの

| 版 | 中身 |
| --- | --- |
| `v1.1.1` | docs（cop 衝突・`assert_includes` の罠・利用側の上書きで gem の修正が届かない形） |
| `v1.1.2` | docs（バンプとタグを分ける。pooza/ginseng-style#59） |
| `v1.1.3` | ⚠ **配る既定の `TargetRubyVersion` が 3.3 → 3.4**（pooza/ginseng-style#61） |

⚠ このリポジトリは `.rubocop.yml` で `TargetRubyVersion` を明示しているので、配る既定が動いても実効は変わらない。

## 確認したこと

- ⚠⚠ **`--show-cops` の差分 — ゼロ**
- ⚠⚠ **`--list-target-files` の差分 — ゼロ**
- `rubocop` — **13 files, no offenses**
- `rake test` — **14 tests / 23 assertions / 0 failures / 0 errors**