### PR TITLE
chore: タグを打つ workflow を置く（ginseng-style#65）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: release
+
+# ⚠⚠ 手順の正本は ginseng-style の composite action 側。ここは薄いままにする
+# （pooza/ginseng-style#65。test.yml が ruby-check を呼んでいるのと同じ形）。
+#
+# ⚠ このリポジトリは mode: manual。**着手時にバンプする**ので、push で打つと
+# マイルストーンの 1 本目の PR が載った時点で出荷されてしまう。
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# ⚠⚠ タグを作るので書き込みが要る。既定の workflow 権限は read。
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # ⚠⚠ 「配布物を変えたのに version を上げていない」の判定は**タグとの差分**で
+          # 見る。浅いチェックアウトではタグにも履歴にも届かない。
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: pooza/ginseng-style/.github/actions/release-tag@v1.1.6
+        with:
+          mode: manual
+          # ⚠⚠ 既定は無い。**このリポジトリが配る中身**を列挙する。
+          paths: bin config lib ginseng-redis.gemspec
+          token: ${{ github.token }}


### PR DESCRIPTION
## なぜ

🔴 **手で打つ運用は死んでいた。** 2026-08-27 の実測で `ginseng-*` 4 gem に**計 8 版ぶんの出荷が滞留**していた。**このリポジトリはその 1 つ。**

手順本体は [ginseng-style の composite action `release-tag`](https://github.com/pooza/ginseng-style/blob/main/.github/actions/release-tag/action.yml) にある（pooza/ginseng-style#65）。ここは `@v1.1.6` で呼ぶだけの薄い caller。

## 何をするか

- **タグの正本は `config/lib.yaml` の `package.version`。** `v<version>` が無ければ打つ
- ⚠ **`mode: manual`** — 着手時バンプをするので、引き金は `workflow_dispatch`
- ⚠ push のたびに「**配布物を変えたのに `v<version>` のまま**」を検査して赤で教える

## `paths`

```
bin config lib ginseng-redis.gemspec
```

⚠⚠ **既定は無い。** リポジトリごとに配る中身が違うので、それらしい既定を置くと**この検査が一番効いてほしい場面で黙る**。⚠ **`*.gemspec` を必ず入れている**（`required_ruby_version` と依存がここにある）。⚠ `test/` は入れない。

## マージ後にどうなるか（実測済み）

現在の version は `2.0.5`。🟡 **`v2.0.5` はまだ無い**（最新タグは `v2.0.3`、**2024-04-29**）。マージ後の push は `::notice v2.0.5 はまだ無い（出荷は workflow_dispatch）` で**緑**になる。⚠ 出荷は別途、リリース前レビューのあとに `workflow_dispatch` を押す。

## パイロットで 3 経路とも実証済み

[pooza/ginseng-piefed#9](https://github.com/pooza/ginseng-piefed/pull/9)（push で緑 → `workflow_dispatch` で `v0.1.1` を作成 → 再実行で「既にある」）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)