### PR TITLE
chore: ginseng-style を SHA で固定する（v1.1.8）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pooza/ginseng-style/.github/actions/release-tag@v1.1.7
+      - uses: pooza/ginseng-style/.github/actions/release-tag@dcd530d88b613ed67e908822da428710bd8351ad # v1.1.8
         with:
           mode: manual
           # ⚠⚠ 既定は無い。**このリポジトリが配る中身**を列挙する。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pooza/ginseng-style/.github/actions/release-tag@v1.1.6
+      - uses: pooza/ginseng-style/.github/actions/release-tag@v1.1.7
         with:
           mode: manual
           # ⚠⚠ 既定は無い。**このリポジトリが配る中身**を列挙する。

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
             dsn: redis://redis:6379/1
           YAML
       # ⚠ 手順の正本は pooza/ginseng-style。ここには matrix と services と schedule だけ置く。
-      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.7
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@dcd530d88b613ed67e908822da428710bd8351ad # v1.1.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
             dsn: redis://redis:6379/1
           YAML
       # ⚠ 手順の正本は pooza/ginseng-style。ここには matrix と services と schedule だけ置く。
-      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.4
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@v1.1.7

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,7 @@ gem 'ginseng-core', github: 'pooza/ginseng-core', require: 'ginseng'
 
 group :development, :test do
   # ⚠ rubocop 本体とプラグインはこの gem が依存として持つ。設定の正本も同じ場所。
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.7', require: false
+  # ⚠⚠ タグではなく SHA で固定する（pooza/ginseng-style#75）。タグは付け替えられる。
+  gem 'ginseng-style', github: 'pooza/ginseng-style',
+      ref: 'dcd530d88b613ed67e908822da428710bd8351ad', require: false # v1.1.8
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'ginseng-core', github: 'pooza/ginseng-core', require: 'ginseng'
 
 group :development, :test do
   # ⚠ rubocop 本体とプラグインはこの gem が依存として持つ。設定の正本も同じ場所。
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.4', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.7', require: false
 end


### PR DESCRIPTION
## なぜ

⚠⚠ **タグは付け替えられるので `@vX.Y.Z` は固定になっていない**（pooza/ginseng-style#75）。特に [release-tag](https://github.com/pooza/ginseng-style/blob/main/.github/actions/release-tag/action.yml) は**このリポジトリの `contents: write` トークンを受け取る**ため、動く ref のままだと `ginseng-style` を取られた側が**このリポジトリの ref を作り替えられる**。

参照 3 経路を **`v1.1.8` のタグ SHA** に揃える。

| 経路 | 変更後 |
| --- | --- |
| `Gemfile` | `ref: 'dcd530d88b613ed67e908822da428710bd8351ad'` |
| `test.yml` | `ruby-check@dcd530d88b613ed67e908822da428710bd8351ad` |
| `release.yml` | `release-tag@dcd530d88b613ed67e908822da428710bd8351ad` |

## ⚠ 末尾の `# v1.1.8` はコメント

人が読むためのもの。⚠⚠ **検査には使わない** — 週次の [gem-watch](https://github.com/pooza/ginseng-style/blob/main/.github/workflows/gem-watch.yml) は **SHA からタグを引いて突き合わせる**。規約に頼ると、ずれても気づけないため。

🔴 **タグの無い SHA を刺していたら赤になる**（レビューを通っていないコミットを刺しているということ）。

## ⚠ `Gemfile` が複数行になっている

`config/rubocop.yml` の `Layout/LineLength` が `Max: 100` で、SHA を書くと 1 行に収まらないため。⚠ **`gem-watch` 側も複数行の宣言を読めるようにしてある**（`gem 'ginseng-style'` の行から、末尾がカンマでない行までを 1 本に畳む）。

## 実測

`v1.1.4`〜`v1.1.8` で **`config/rubocop.yml` と `ginseng-style.gemspec` は 1 行も変わっていない**ので lint 結果は変わらない。パイロット（`ginseng-core`）で確認済み:

| 検査 | 結果 |
| --- | --- |
| `bundle exec rubocop` | ✅ 84 files, no offenses |
| `--show-cops` の差分 | ✅ ゼロ |
| `--list-target-files` の差分 | ✅ ゼロ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)