### PR TITLE
chore: ginseng-style を v1.1.10 に上げる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pooza/ginseng-style/.github/actions/release-tag@dcd530d88b613ed67e908822da428710bd8351ad # v1.1.8
+      - uses: pooza/ginseng-style/.github/actions/release-tag@e5917622d069be324c6879c2a1d2522069d48d2c # v1.1.10
         with:
           mode: manual
           # ⚠⚠ 既定は無い。**このリポジトリが配る中身**を列挙する。

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
             dsn: redis://redis:6379/1
           YAML
       # ⚠ 手順の正本は pooza/ginseng-style。ここには matrix と services と schedule だけ置く。
-      - uses: pooza/ginseng-style/.github/actions/ruby-check@dcd530d88b613ed67e908822da428710bd8351ad # v1.1.8
+      - uses: pooza/ginseng-style/.github/actions/ruby-check@e5917622d069be324c6879c2a1d2522069d48d2c # v1.1.10

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :development, :test do
   # ⚠ rubocop 本体とプラグインはこの gem が依存として持つ。設定の正本も同じ場所。
   # ⚠⚠ タグではなく SHA で固定する（pooza/ginseng-style#75）。タグは付け替えられる。
   gem 'ginseng-style', github: 'pooza/ginseng-style',
-      ref: 'dcd530d88b613ed67e908822da428710bd8351ad', require: false # v1.1.8
+      ref: 'e5917622d069be324c6879c2a1d2522069d48d2c', require: false # v1.1.10
 end


### PR DESCRIPTION
## なぜ

`ginseng-style` の参照 3 経路を **`v1.1.10` の SHA** に上げる。

| 経路 | 変更前 | 変更後 |
| --- | --- | --- |
| `Gemfile` の `ref:` | `dcd530d…`（v1.1.8） | `e591762…`（**v1.1.10**） |
| `test.yml` の `ruby-check@` | 同上 | 同上 |
| `release.yml` の `release-tag@` | 同上 | 同上 |

## ⚠⚠ これで週次の警告が 0 に戻る

`gem-watch` の `pins` に **warning が 21 件**（7 gem × 3 経路）立っていた。🔴 **赤でない警告が常時立っていると、いずれ読まれなくなる。**

⚠ 原因は「**docs を 1 行直すだけでリリースになる**」ことだった（2026-08-27 の 5 リリース中 3 本が docs のみ）。`v1.1.10` で **`docs/` を `spec.files` と `paths` の両方から外した**ので、以降は文章の修正で版が動かない。

## `v1.1.8`〜`v1.1.10` の中身

| タグ | 配布物の差分 |
| --- | --- |
| `v1.1.9` | `docs/workflow.md`（タグ参照を error に上げた記述） |
| `v1.1.10` | `ginseng-style.gemspec` / `README.md` / `lib/ginseng/style.rb` |

🔴 **`config/rubocop.yml` は `v1.1.4` から 1 行も変わっていない。** lint 結果は変わらない。

⚠ `v1.1.10` で **`Ginseng::Style.docs_dir` を削除**している（docs を同梱しなくなり、存在しないパスを返すため）。⚠ 呼び出し元は手元 52 リポジトリと org のコード検索で **0 件**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
